### PR TITLE
Add .model to the list of file extensions

### DIFF
--- a/grammars/gisdk.cson
+++ b/grammars/gisdk.cson
@@ -2,6 +2,7 @@
 'fileTypes': [
   'rsc'
   'gisdk'
+  'model'
 ]
 'name': 'GISDK'
 'patterns': [


### PR DESCRIPTION
@DavidOry 

This is a small change that associates the .model file extension as one that uses the GISDK syntax highlighting.

Publish the update using:
https://flight-manual.atom.io/hacking-atom/sections/publishing/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wsp-sag/language-gisdk/2)
<!-- Reviewable:end -->
